### PR TITLE
[MRESOURCES-284] Support JSON format for parameter filter files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenFilteringVersion>3.2.0</mavenFilteringVersion>
+    <mavenFilteringVersion>3.3.0-SNAPSHOT</mavenFilteringVersion>
     <mavenVersion>3.1.0</mavenVersion>
     <javaVersion>7</javaVersion>
     <project.build.outputTimestamp>2020-08-05T15:25:21Z</project.build.outputTimestamp>
@@ -78,6 +78,10 @@ under the License.
   <contributors>
     <contributor>
       <name>Graham Leggett</name>
+    </contributor>
+    <contributor>
+      <name>Imad BELMOUJAHID</name>
+      <email>BELMOUJAHID.I@Gmail.Com</email>
     </contributor>
   </contributors>
     

--- a/src/main/java/org/apache/maven/plugins/resources/ResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/resources/ResourcesMojo.java
@@ -50,7 +50,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 /**
  * Copy resources for the main source code to the main output directory. Always uses the project.build.resources element
  * to specify the resources to copy.
- *
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
  * @author <a href="michal.maczka@dimatics.com">Michal Maczka</a>
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  * @author Andreas Hoheneder
@@ -209,6 +209,14 @@ public class ResourcesMojo
     protected LinkedHashSet<String> delimiters;
 
     /**
+     * This parameter is used in particular for filters properties files with format json.
+     * if this parameter is not empty, we select all the parameters who are the nodes start with this parameter
+     * This helps us to add a ROOT node FOR EACH environment in a same JSON file
+     */
+    @Parameter
+    protected String rootNode;
+
+    /**
      * Use default delimiters in addition to custom delimiters, if any.
      *
      * @since 2.4
@@ -348,6 +356,9 @@ public class ResourcesMojo
 
             // Handle MRESOURCES-171
             mavenResourcesExecution.setPropertiesEncoding( propertiesEncoding );
+
+            // Set rootNode for new feature with json file ### MRESOURCES-284 ###
+            mavenResourcesExecution.setRootNode( rootNode );
 
             if ( nonFilteredFileExtensions != null )
             {

--- a/src/test/java/org/apache/maven/plugins/resources/BasicPropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/plugins/resources/BasicPropertyUtilsTest.java
@@ -24,6 +24,9 @@ import java.util.Properties;
 
 import org.apache.maven.shared.filtering.PropertyUtils;
 
+/**
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
+ */
 public class BasicPropertyUtilsTest
     extends AbstractPropertyUtilsTest
 {
@@ -58,13 +61,14 @@ public class BasicPropertyUtilsTest
 
     /**
      * load property test case can be adjusted by modifying the basic.properties and basic_validation properties
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
      *
      * @throws Exception
      */
     public void testBasicLoadProperty_FF()
         throws Exception
     {
-        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, false, false );
+        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, false, false, null );
 
         assertNotNull( prop );
         assertTrue( validateProperties( prop ) );
@@ -72,13 +76,14 @@ public class BasicPropertyUtilsTest
 
     /**
      * load property test case can be adjusted by modifying the basic.properties and basic_validation properties
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
      *
      * @throws Exception
      */
     public void testBasicLoadProperty_TF()
         throws Exception
     {
-        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, true, false );
+        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, true, false, null );
 
         assertNotNull( prop );
         assertTrue( validateProperties( prop ) );
@@ -86,13 +91,14 @@ public class BasicPropertyUtilsTest
 
     /**
      * load property test case can be adjusted by modifying the basic.properties and basic_validation properties
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
      *
      * @throws Exception
      */
     public void testBasicLoadProperty_TT()
         throws Exception
     {
-        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, true, true );
+        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, true, true, null );
 
         validationProp.putAll( System.getProperties() );
         assertNotNull( prop );
@@ -101,13 +107,14 @@ public class BasicPropertyUtilsTest
 
     /**
      * load property test case can be adjusted by modifying the basic.properties and basic_validation properties
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
      *
      * @throws Exception
      */
     public void testNonExistentProperty()
         throws Exception
     {
-        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, true, true );
+        Properties prop = PropertyUtils.loadPropertyFile( propertyFile, true, true, null );
 
         validationProp.putAll( System.getProperties() );
         assertNotNull( prop );

--- a/src/test/java/org/apache/maven/plugins/resources/PropertyUtilsExceptionTest.java
+++ b/src/test/java/org/apache/maven/plugins/resources/PropertyUtilsExceptionTest.java
@@ -25,11 +25,15 @@ import java.io.FileNotFoundException;
 import org.apache.maven.shared.filtering.PropertyUtils;
 import org.junit.Test;
 
+/**
+ * @author <a href="mailto:BELMOUJAHID.I@Gmail.Com>Imad BELMOUJAHID</a> @ImadBL
+ */
 public class PropertyUtilsExceptionTest
 {
 
     /**
      * load property test case can be adjusted by modifying the basic.properties and basic_validation properties
+     * I added a null for this parameter (rootNode) because it is only used with json file @ImadBL
      *
      * @throws Exception
      */
@@ -37,6 +41,6 @@ public class PropertyUtilsExceptionTest
     public void loadPropertyFileShouldFailWithFileNotFoundException()
         throws Exception
     {
-        PropertyUtils.loadPropertyFile( new File( "NON_EXISTENT_FILE" ), true, true );
+        PropertyUtils.loadPropertyFile( new File( "NON_EXISTENT_FILE" ), true, true, null );
     }
 }


### PR DESCRIPTION
Hi,

This concerns the **maven-resources-plugin** (3.2.1-SNAPSHOT) and **maven-filtering** (3.3.0-SNAPSHOT) plugins.
with this evolution it is now possible to add configuration files with json format. the second part of this evolution is to have to use a one configuration json file for all environments (dev, preprod, prod...etc )
for more example check: MRESOURCES-284

please note that you must accept the PR first for **maven-filtering** (3.3.0-SNAPSHOT) 
because **maven-resources-plugin** (3.2.1-SNAPSHOT) need **maven-filtering** (3.3.0-SNAPSHOT) 

if you have any questions do not hesitate, hoping that I have detailed well

Best regards
Imad BELMOUJAHID
@ImadBL