### PR TITLE
doc: adds alternative variable syntax using @ delimiters to the documentation

### DIFF
--- a/src/site/apt/examples/filter.apt
+++ b/src/site/apt/examples/filter.apt
@@ -29,7 +29,7 @@
 Filtering
 
  Variables can be included in your resources. These variables, denoted by the
- <<<$\{...\}>>> delimiters, can come from the system properties, your project
+ <<<$\{...\}>>> or <<<@...@>>> delimiters, can come from the system properties, your project
  properties, from your filter resources and from the command line.
 
  For example, if we have a resource <<<src/main/resources/hello.txt>>> containing


### PR DESCRIPTION
This pull request fixes a part of the documentation regarding filtering and the use of variables.

In the documentation was only the information that variables can be used via ${...} but there is also the option to use @...@ syntax to reference variables.

This pull request extends the documentation with information about this alternative syntax.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

