### PR TITLE
[MRESOURCES-269] Ensure symlinks do not fail to copy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenFilteringVersion>3.3.0</mavenFilteringVersion>
+    <mavenFilteringVersion>3.3.1-SNAPSHOT</mavenFilteringVersion>
     <mavenVersion>3.2.5</mavenVersion>
     <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2022-07-23T17:49:18Z</project.build.outputTimestamp>


### PR DESCRIPTION
Updating permissions for symlinks caused a FileNotFoundException.  This was fixed in maven-filtering in MSHARED-1112

