### PR TITLE
[MRESOURCES-293] Make resources param not read-only

### DIFF
--- a/src/main/java/org/apache/maven/plugins/resources/ResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/resources/ResourcesMojo.java
@@ -80,7 +80,7 @@ public class ResourcesMojo
     /**
      * The list of resources we want to transfer.
      */
-    @Parameter( defaultValue = "${project.resources}", required = true, readonly = true )
+    @Parameter( defaultValue = "${project.resources}", required = true )
     private List<Resource> resources;
 
     /**

--- a/src/main/java/org/apache/maven/plugins/resources/TestResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/resources/TestResourcesMojo.java
@@ -49,7 +49,7 @@ public class TestResourcesMojo
     /**
      * The list of resources we want to transfer.
      */
-    @Parameter( defaultValue = "${project.testResources}", required = true, readonly = false )
+    @Parameter( defaultValue = "${project.testResources}", required = true )
     private List<Resource> resources;
 
     /**


### PR DESCRIPTION
Actually, test-resources were already not read-only, change applies only to resources mojo.

---

https://issues.apache.org/jira/browse/MRESOURCES-293

