### PR TITLE
[MRESOURCES-288] Make tests-jar reproducible

### DIFF
--- a/src/it/user-filters/pom.xml
+++ b/src/it/user-filters/pom.xml
@@ -52,11 +52,6 @@
             <version>@project.version@</version>
             <classifier>tests</classifier>
           </dependency>
-          <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.7</version>
-          </dependency>          
         </dependencies>
       </plugin>
     </plugins>

--- a/src/test/java/org/apache/maven/plugins/resources/stub/MavenProjectBasicStub.java
+++ b/src/test/java/org/apache/maven/plugins/resources/stub/MavenProjectBasicStub.java
@@ -37,7 +37,7 @@ public class MavenProjectBasicStub extends MavenProjectStub {
     public MavenProjectBasicStub(String id) {
         properties = new Properties();
         identifier = id;
-        testRootDir = PlexusTestCase.getBasedir() + "/target/test-classes/unit/test-dir/" + identifier;
+        testRootDir = PlexusTestCase.getBasedir() + "/target/unit/test-dir/" + identifier;
 
         if (!FileUtils.fileExists(testRootDir)) {
             FileUtils.mkdir(testRootDir);


### PR DESCRIPTION
By moving out UT outputs into separate place, to not have them packed up into it. Also removing superfluous dependency in user filters IT, as plugin already uses commons-io that is even newer.

---

https://issues.apache.org/jira/browse/MRESOURCES-288