### PR TITLE
reduce dependency scope of plexus-utils and commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,18 +123,18 @@ under the License.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>3.5.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
       <version>${mavenFilteringVersion}</version>
     </dependency>
-    <!-- Upgrade of transitive commons-io 2.4 of maven-shared-utils of maven-filtering. -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.11.0</version>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
maven-filtering now uses current commons-io