### PR TITLE
[MRESOURCES-299] Be more accurate on using filtering element

### DIFF
--- a/src/site/apt/examples/filter.apt
+++ b/src/site/apt/examples/filter.apt
@@ -72,7 +72,7 @@ mvn resources:resources
 Hello ${name}
 +-----+
 
- However, if we add a <<<\<filtering\>>>> tag to our POM and set it to <<<true>>> like this:
+ However, if we add a <<<\<filtering\>>>> element to our POM and set it to <<<true>>> like this:
 
 +-----+
 <project>


### PR DESCRIPTION
It targets 3.x, as the [published site](https://maven.apache.org/plugins/maven-resources-plugin) is for 3.3.1 (and not 4.0.0-beta-1 from master).