### PR TITLE
Replace `FileUtils.fileExists(String)` with JDK provided API

### DIFF
--- a/src/test/java/org/apache/maven/plugins/resources/TestResourcesTest.java
+++ b/src/test/java/org/apache/maven/plugins/resources/TestResourcesTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.plugins.resources;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +33,6 @@ import org.apache.maven.api.plugin.testing.stubs.SessionMock;
 import org.apache.maven.impl.InternalSession;
 import org.apache.maven.plugins.resources.stub.MavenProjectResourcesStub;
 import org.apache.maven.shared.filtering.Resource;
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
@@ -83,11 +83,11 @@ public class TestResourcesTest {
 
         String resourcesDir = project.getTestOutputDirectory();
 
-        assertTrue(FileUtils.fileExists(resourcesDir + "/file4.txt"));
-        assertTrue(FileUtils.fileExists(resourcesDir + "/package/file3.nottest"));
-        assertTrue(FileUtils.fileExists(resourcesDir + "/notpackage/file1.include"));
-        assertTrue(FileUtils.fileExists(resourcesDir + "/package/test"));
-        assertTrue(FileUtils.fileExists(resourcesDir + "/notpackage/test"));
+        assertTrue(new File(resourcesDir + "/file4.txt").exists());
+        assertTrue(new File(resourcesDir + "/package/file3.nottest").exists());
+        assertTrue(new File(resourcesDir + "/notpackage/file1.include").exists());
+        assertTrue(new File(resourcesDir + "/package/test").exists());
+        assertTrue(new File(resourcesDir + "/notpackage/test").exists());
     }
 
     private static final String LOCAL_REPO = "/target/local-repo";

--- a/src/test/java/org/apache/maven/plugins/resources/stub/MavenProjectBuildStub.java
+++ b/src/test/java/org/apache/maven/plugins/resources/stub/MavenProjectBuildStub.java
@@ -159,19 +159,19 @@ public class MavenProjectBuildStub extends MavenProjectBasicStub {
     }
 
     public void cleanBuildEnvironment() throws Exception {
-        if (FileUtils.fileExists(resourcesDirectory)) {
+        if (new File(resourcesDirectory).exists()) {
             FileUtils.deleteDirectory(resourcesDirectory);
         }
 
-        if (FileUtils.fileExists(testResourcesDirectory)) {
+        if (new File(testResourcesDirectory).exists()) {
             FileUtils.deleteDirectory(testResourcesDirectory);
         }
 
-        if (FileUtils.fileExists(outputDirectory)) {
+        if (new File(outputDirectory).exists()) {
             FileUtils.deleteDirectory(outputDirectory);
         }
 
-        if (FileUtils.fileExists(testOutputDirectory)) {
+        if (new File(testOutputDirectory).exists()) {
             FileUtils.deleteDirectory(testOutputDirectory);
         }
     }
@@ -180,11 +180,11 @@ public class MavenProjectBuildStub extends MavenProjectBasicStub {
         // populate dummy resources and dummy test resources
 
         // setup src dir
-        if (!FileUtils.fileExists(resourcesDirectory)) {
+        if (!new File(resourcesDirectory).exists()) {
             FileUtils.mkdir(resourcesDirectory);
         }
 
-        if (!FileUtils.fileExists(testResourcesDirectory)) {
+        if (!new File(testResourcesDirectory).exists()) {
             FileUtils.mkdir(testResourcesDirectory);
         }
 
@@ -192,11 +192,11 @@ public class MavenProjectBuildStub extends MavenProjectBasicStub {
         createFiles(resourcesDirectory, testResourcesDirectory);
 
         // setup target dir
-        if (!FileUtils.fileExists(outputDirectory)) {
+        if (!new File(outputDirectory).exists()) {
             FileUtils.mkdir(outputDirectory);
         }
 
-        if (!FileUtils.fileExists(testOutputDirectory)) {
+        if (!new File(testOutputDirectory).exists()) {
             FileUtils.mkdir(testOutputDirectory);
         }
     }


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.codehaus.plexus.PlexusFileUtilsRecipes%24FileExistsStringRecipe?organizationId=YTA5ODhiOTYtNDI5OS00OGY3LTg0NjctNGZiNmI4OTY1ZjY3