### PR TITLE
Add integration test for Maven 4 compatibility (fixes #312, #436)

### DIFF
--- a/src/it/gh-312/pom.xml
+++ b/src/it/gh-312/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.maven-resources-plugin.its</groupId>
+  <artifactId>gh-312</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>GH-312: Maven 4 Compatibility Test</name>
+  <description>Test for issue #312 (and duplicate #436): Build failed with Maven 4.0.0-beta-1
+    Error: Unable to lookup Mojo - Error while initializing binding BindingToConstructor</description>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>default-resources</id>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/gh-312/src/main/resources/test.properties
+++ b/src/it/gh-312/src/main/resources/test.properties
@@ -1,0 +1,4 @@
+# Test properties file for gh-312
+project.name=${project.name}
+project.version=${project.version}
+test.value=This is a test

--- a/src/it/gh-312/verify.groovy
+++ b/src/it/gh-312/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Verify that the build succeeded and resources were processed
+File target = new File(basedir, "target/classes")
+assert target.exists() : "target/classes directory should exist"
+
+File testProps = new File(target, "test.properties")
+assert testProps.exists() : "test.properties should be copied to target/classes"
+
+// Verify filtering worked (project.name should be replaced)
+String content = testProps.text
+assert content.contains("GH-312") : "Filtering should have replaced project.name"
+assert content.contains("1.0-SNAPSHOT") : "Filtering should have replaced project.version"
+
+println "✓ Maven 4 compatibility test passed - resources processed successfully (GH-312)"
+return true


### PR DESCRIPTION
## Summary

Add integration test `gh-312` to verify Maven 4 compatibility with maven-resources-plugin beta-2-SNAPSHOT.

## Changes

- Add `src/it/gh-312/` integration test using Maven Invoker Plugin
- Test verifies resource copying with filtering enabled
- Confirms no BuildContext binding errors occur with Maven 4

## Testing

The test has been verified to:
- ✅ Pass with Maven 4.0.0-rc-4 and rc-5 on beta-2-SNAPSHOT
- ❌ Fail with Maven 4 on version 4.0.0-beta-1 (confirming the bug exists)

## Issues

This test confirms that issues #312 and #436 (duplicate) are fixed in beta-2-SNAPSHOT.

Both issues reported:
```
Unable to lookup Mojo: Failed to call method static org.sonatype.plexus.build.incremental.BuildContext 
org.apache.maven.plugins.resources.Providers.buildContext(): org/codehaus/plexus/logging/AbstractLogEnabled
```

The integration test verifies this error no longer occurs and the plugin works correctly with Maven 4.

Closes #312
Closes #436