### PR TITLE
Update to Maven 4.0.0-rc5

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
-      ff-maven: "4.0.0-rc-4"                     # Maven version for fail-fast-build
-      maven-matrix: '[ "4.0.0-rc-4" ]'
+      ff-maven: "4.0.0-rc-5"                     # Maven version for fail-fast-build
+      maven-matrix: '[ "4.0.0-rc-5" ]'
       jdk-matrix: '[ "17", "21" ]'

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenVersion>4.0.0-rc-4</mavenVersion>
+    <mavenVersion>4.0.0-rc-5</mavenVersion>
     <javaVersion>17</javaVersion>
 
     <guiceVersion>6.0.0</guiceVersion>
@@ -87,6 +87,7 @@ under the License.
 
     <project.build.outputTimestamp>2024-06-26T08:24:00Z</project.build.outputTimestamp>
     <version.maven-invoker-plugin>3.9.1</version.maven-invoker-plugin>
+    <version.palantirJavaFormat>2.81.0</version.palantirJavaFormat>
   </properties>
 
   <dependencyManagement>

--- a/src/it/user-filters/invoker.properties
+++ b/src/it/user-filters/invoker.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.systemPropertiesFile = test.properties
+invoker.userPropertiesFile = test.properties


### PR DESCRIPTION
Includes
* Palantir format for Java 25
* Replacement of deprecated access to invoker.properties

blocked by #442