### PR TITLE
Fix user-filters IT fixture for Maven 4 compatibility

### DIFF
--- a/src/test/java/org/apache/maven/plugins/resources/filters/ItFilter.java
+++ b/src/test/java/org/apache/maven/plugins/resources/filters/ItFilter.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
@@ -68,11 +69,14 @@ public class ItFilter implements MavenResourcesFiltering {
 
             lines.add("foo");
             lines.add("version=" + mavenResourcesExecution.getMavenProject().getVersion());
-            lines.add("toto="
-                    + mavenResourcesExecution
-                            .getMavenSession()
-                            .getSystemProperties()
-                            .getProperty("toto"));
+            MavenSession session = mavenResourcesExecution.getMavenSession();
+            // Maven 4 splits CLI -D into user properties strictly; Maven 3 merged them into
+            // system properties as well. Consult user properties first, then fall back.
+            String toto = session.getUserProperties().getProperty("toto");
+            if (toto == null) {
+                toto = session.getSystemProperties().getProperty("toto");
+            }
+            lines.add("toto=" + toto);
             Path target = f.toPath();
             Files.createDirectories(target.getParent());
             Files.write(target, lines);


### PR DESCRIPTION
## Summary

The `user-filters` integration test is the single IT failing under Maven 4.0.0-rc-5 on the 3.x maintenance line, which leaves PR #466 ("enable build with Maven 4") in an UNSTABLE state. This PR fixes the IT fixture so the rc-5 matrix turns green.

## Root cause

The IT exercises a user-supplied `MavenResourcesFiltering` (`ItFilter`) and passes `toto=titi` via `invoker.userPropertiesFile = test.properties`, which `maven-invoker-plugin` forwards as `-Dtoto=titi` to the forked Maven.

- On Maven 3, CLI `-D` values land in both `MavenSession.getUserProperties()` and the view returned by `getSystemProperties()`.
- On Maven 4 (rc-5 and current `apache/maven` master), `getSystemProperties()` is strict and returns only actual JVM system properties; CLI `-D` lives exclusively in `getUserProperties()`.

`ItFilter.filterResources` only read `getSystemProperties()`, so under Maven 4 the generated `foo.txt` contained `toto=null` and the post-build groovy assertion `assert content.contains('toto=titi')` failed.

The bug is entirely in the IT fixture; the production `MavenResourcesPlugin` is unaffected (it routes through `maven-filtering`, which already consults both buckets).

## Fix

Consult `getUserProperties()` first in `ItFilter`, falling back to `getSystemProperties()`. Compiles and runs on Maven 3.9.x and Maven 4.0.0-rc-5+.

## Verification

- `mvn -Prun-its verify` against Maven 4.0.0-rc-5 (macOS aarch64, JDK 17): **27/27 ITs pass** (was 26/27).
- `target/it/user-filters/target/classes/foo.txt` now contains `toto=titi`.

## Context

- Unblocks #466 (CI matrix flip to `maven4-enabled: true`).
- Part of the broader "[REVIEW REQUEST] Maven 4 compatibility test fixes - 17 PRs targeting 4.0.0-rc-6" effort on `dev@maven` (2026-06-05).
- No production code change; no POM/dependency bump.
- Checked `master` (4.x rewrite, `4.0.0-beta-2-SNAPSHOT`): equivalent file already consults `getUserProperties()` — no follow-up needed there.
