### PR TITLE
Build against Maven 4.0.0-rc-6, and honour <skip> on testResources

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      ff-maven: "4.0.0-rc-4"                     # Maven version for fail-fast-build
-      maven-matrix: '[ "4.0.0-rc-4" ]'
+      ff-maven: "4.0.0-rc-6"                     # Maven version for fail-fast-build
+      maven-matrix: '[ "4.0.0-rc-6" ]'
       jdk-matrix: '[ "17", "21" ]'

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenVersion>4.0.0-rc-4</mavenVersion>
+    <mavenVersion>4.0.0-rc-6</mavenVersion>
     <javaVersion>17</javaVersion>
 
     <guiceVersion>7.0.0</guiceVersion>

--- a/src/main/java/org/apache/maven/plugins/resources/TestResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/resources/TestResourcesMojo.java
@@ -67,6 +67,11 @@ public class TestResourcesMojo extends ResourcesMojo {
         // configurator writes the superclass one, leaving this class's field false
         // however the build configured <skip>. Reading both is what makes
         // <skip>true</skip> reach this goal at all.
+        //
+        // TODO temporary: drop the isSkip() half once apache/maven#12626 is in a
+        // release. That fixes the cause in the core configurator, where
+        // buildFieldCache() lets a parent field shadow the child's, and then this
+        // class's own field will be configured directly.
         if (skip || isSkip()) {
             getLog().info("Not copying test resources");
             return;

--- a/src/main/java/org/apache/maven/plugins/resources/TestResourcesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/resources/TestResourcesMojo.java
@@ -62,7 +62,12 @@ public class TestResourcesMojo extends ResourcesMojo {
      * {@inheritDoc}
      */
     public void execute() throws MojoException {
-        if (skip) {
+        // isSkip() reads ResourcesMojo's own field. Both classes declare a private
+        // "skip", so the two collapse into a single descriptor parameter and the
+        // configurator writes the superclass one, leaving this class's field false
+        // however the build configured <skip>. Reading both is what makes
+        // <skip>true</skip> reach this goal at all.
+        if (skip || isSkip()) {
             getLog().info("Not copying test resources");
             return;
         }


### PR DESCRIPTION
Moves `mavenVersion` to the current RC and pins the same version explicitly in the Verify workflow.

That surfaced a pre-existing bug. `MRESOURCES-131` sets `<skip>true</skip>` in `pluginManagement` and asserts the test resource is not copied; it has been failing since **4.0.0-rc-5** — main resources skips, `testResources` does not:

```
--- resources:resources (default-resources) ---
[INFO] Skipping the execution.
--- resources:testResources (default-testResources) ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
```

`ResourcesMojo` and `TestResourcesMojo` both declare a private field named `skip`. They collapse into a single descriptor parameter for the `testResources` goal, and the configurator writes the superclass field — so `TestResourcesMojo`'s own field stays `false` whatever the build configured, and its guard never fires. Reading both restores the documented behaviour while keeping `maven.test.skip` and `maven.resources.skip` working as before.

Renaming the field so the two stop shadowing is not an option: the descriptor generator then sees two parameters called `skip` for one goal and fails with `skip has been declared multiple times in mojo with goal: testResources`.

`mvn verify -Prun-its` passes, 24 unit tests, 0 failures. Part of apache/maven#12676. Verified green on a fork before opening.