### PR TITLE
Use maven4-build instead of hand-rolling the matrix

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
-      ff-maven: "4.0.0-rc-6"                     # Maven version for fail-fast-build
-      maven-matrix: '[ "4.0.0-rc-6" ]'
+      maven4-build: true
+      maven4-version: '4.0.0-rc-6' # the same as used in project
       jdk-matrix: '[ "17", "21" ]'


### PR DESCRIPTION
The shared workflow already has a switch for a Maven-4-only build. Setting `ff-maven` and `maven-matrix` by hand does the same thing, but repeats the version twice, needs re-pinning in two places on every RC, and skips the `{jdk: 8}` exclude that `maven4-build` adds for you — harmless here only because `jdk-matrix` is pinned to 17 and 21.

```diff
-      ff-maven: "4.0.0-rc-6"                     # Maven version for fail-fast-build
-      maven-matrix: '[ "4.0.0-rc-6" ]'
+      maven4-build: true
+      maven4-version: '4.0.0-rc-6' # the same as used in project
```

Matches how the other Maven 4 plugins are configured — clean, install, deploy, compiler, source, archiver and filtering all use `maven4-build`. No behaviour change intended. Context in apache/maven#12676.