### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/binaries-filtering.md.vm
+++ b/src/site/markdown/examples/binaries-filtering.md.vm
@@ -1,3 +1,10 @@
+---
+title: Binaries Filtering
+author: 
+  - Olivier Lamy
+date: 2008-10-14
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/copy-resources.md.vm
+++ b/src/site/markdown/examples/copy-resources.md.vm
@@ -1,3 +1,10 @@
+---
+title: Copy Resources
+author: 
+  - Olivier Lamy
+date: 2008-09-13
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/custom-resource-filters.md.vm
+++ b/src/site/markdown/examples/custom-resource-filters.md.vm
@@ -1,3 +1,10 @@
+---
+title: Custom resource filters
+author: 
+  - Olivier Lamy
+date: 2010-09-24
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/encoding.md.vm
+++ b/src/site/markdown/examples/encoding.md.vm
@@ -1,3 +1,11 @@
+---
+title: Specifying a character encoding scheme
+author: 
+  - Franz Allan See
+  - Karl Heinz Marbaise
+date: 2016-05-13
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/escape-filtering.md.vm
+++ b/src/site/markdown/examples/escape-filtering.md.vm
@@ -1,3 +1,10 @@
+---
+title: Escape Filtering
+author: 
+  - Olivier Lamy
+date: 2008-09-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/filter.md
+++ b/src/site/markdown/examples/filter.md
@@ -1,3 +1,10 @@
+---
+title: Filtering
+author: 
+  - Franz Allan See
+date: 2008-09-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/filtering-properties-files.md.vm
+++ b/src/site/markdown/examples/filtering-properties-files.md.vm
@@ -1,3 +1,10 @@
+---
+title: Filtering Properties Files
+author: 
+  - Dennis Lundberg
+date: 2020-07-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/include-exclude.md
+++ b/src/site/markdown/examples/include-exclude.md
@@ -1,3 +1,10 @@
+---
+title: Including and excluding files and directories
+author: 
+  - Franz Allan See
+date: 2008-09-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/resource-directory.md
+++ b/src/site/markdown/examples/resource-directory.md
@@ -1,3 +1,10 @@
+---
+title: Specifying resource directories
+author: 
+  - Franz Allan See
+date: 2008-09-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Franz Allan See
+date: 2013-07-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - Franz Allan See
+date: 2011-02-05
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.