### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/src/site/markdown/examples/custom-resource-filters.md.vm
+++ b/src/site/markdown/examples/custom-resource-filters.md.vm
@@ -109,4 +109,4 @@ You must now declare you custom filter in the plugin. mavenFilteringHint must re
  </plugin>
 ```
 
-And that's it \!
+And that's it !

--- a/src/site/markdown/examples/filter.md
+++ b/src/site/markdown/examples/filter.md
@@ -147,7 +147,7 @@ and adding that to our POM
 </project>
 ```
 
-**Warning:** Do not filter files with binary content like images\! This will most likely result in corrupt output.
+**Warning:** Do not filter files with binary content like images! This will most likely result in corrupt output.
 
 If you have both text files and binary files as resources it is recommended to have two separated folders. One folder `src/main/resources` (default) for the resources which are not filtered and another folder `src/main/resources-filtered` for the resources which are filtered.
 


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.