### PR TITLE
Restore mavenFilteringVersion for the usage page (#468)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,9 @@ under the License.
     <!-- Update to 2.x should happen, when plugin prerequisites are lifted to 3.10+ / 4.x -->
     <version.slf4j>1.7.36</version.slf4j>
     <version.plexus-utils>3.6.0</version.plexus-utils>
+
+    <!-- Used by site documentation as well, do not remove -->
+    <mavenFilteringVersion>3.5.1</mavenFilteringVersion>
   </properties>
 
   <dependencies>
@@ -85,7 +88,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-filtering</artifactId>
-      <version>3.5.1</version>
+      <version>${mavenFilteringVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
The usage page still interpolates `${mavenFilteringVersion}`. That property was removed in 38534e3 when the maven-filtering version was inlined, so https://maven.apache.org/plugins/maven-resources-plugin/usage.html prints the unresolved token.

I restored the property at the current 3.5.1 version and pointed the dependency at it. Same approach as apache/maven-remote-resources-plugin#8.

Fixes #468

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MRESOURCES) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MRESOURCES-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MRESOURCES-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

This change is the GitHub issue #468, not a JIRA ticket. I evaluated `mavenFilteringVersion` with `mvn help:evaluate` (it resolves to 3.5.1). I did not run the full IT profile.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
